### PR TITLE
Fix mocktail CLI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This monorepo provides a generic OpenAPI SDK generator and an example project.
 
 ## Workflow
 
-Run `pnpm install` to set up the workspace. Build the generator with `pnpm --filter @mocktailgpt/ts build` and generate the example client with `cd example/vanScrapper && pnpm generate` (which internally calls `mocktail generate`). Use `pnpm lint` and `pnpm test` for quality checks. The `mocktail generate` command accepts `--config`, `--input`, `--output` and `--force` options.
+Run `pnpm install` to set up the workspace. The install step now builds the local `@mocktailgpt/ts` package and links the `mocktail` CLI automatically. After installation you can generate the example client directly with `cd example/vanScrapper && pnpm generate` (which internally calls `mocktail generate`). Use `pnpm lint` and `pnpm test` for quality checks. The `mocktail generate` command accepts `--config`, `--input`, `--output` and `--force` options.
 
 The generator produces a full mocking environment based on MSW. After running
 `mocktail generate` you can start the worker in development mode:

--- a/example/vanScrapper/README.md
+++ b/example/vanScrapper/README.md
@@ -9,7 +9,7 @@ Generate a typed SDK for the van scrapper API and try it in both real and mock m
 ## ⚙️ Generate the SDK
 
 ```bash
-pnpm install
+pnpm install    # builds and links the local mocktail CLI
 pnpm run generate
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "lint": "npm -ws run lint",
     "format": "npm -ws run format",
     "gen": "npm -ws --if-present run gen",
-    "test": "npm -ws run test"
+    "test": "npm -ws run test",
+    "postinstall": "pnpm --filter @mocktailgpt/ts run build && pnpm rebuild @mocktailgpt/ts"
   },
   "devDependencies": {
     "eslint": "^8.56.0",

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm install
+pnpm install


### PR DESCRIPTION
## Summary
- ensure the mocktail CLI is built and linked on install
- update init script to use pnpm
- document automatic CLI build in README files

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684d350a94288328bae803dfd25383a5