### PR TITLE
feat(config): add config loader with zod validation and defineMocktailConfig()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 This repository houses multiple packages for the MocktailGPT project.
 
 ## Packages
+
 - [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
 
 ## Development
+
 Standard tooling is configured at the repository root:
+
 - Prettier for code formatting
 - ESLint with TypeScript support
 - Shared TypeScript settings in `tsconfig.base.json`
+
+See the package README for configuration details.

--- a/package.json
+++ b/package.json
@@ -9,5 +9,10 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.12.1"
+  "packageManager": "pnpm@10.12.1",
+  "devDependencies": {
+    "@types/node": "^24.0.1",
+    "eslint": "^9.29.0",
+    "typescript-eslint": "^8.34.0"
+  }
 }

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -1,3 +1,25 @@
 # @mocktailgpt/ts
 
 CLI tool scaffold for generating TypeScript clients from OpenAPI with MSW mocks.
+
+## Configuration
+
+Create a `mocktail.config.ts` at the root of your project:
+
+```ts
+import { defineMocktailConfig } from '@mocktailgpt/ts'
+
+export default defineMocktailConfig({
+  swagger: './swagger.yaml',
+  output: './src/api/generated',
+  mock: true,
+})
+```
+
+Load it in your scripts with:
+
+```ts
+import { loadConfig } from '@mocktailgpt/ts'
+
+const config = await loadConfig('./mocktail.config.ts')
+```

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -21,5 +21,8 @@
   ],
   "devDependencies": {
     "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "zod": "^3.25.64"
   }
 }

--- a/packages/ts/src/config/loadConfig.ts
+++ b/packages/ts/src/config/loadConfig.ts
@@ -1,0 +1,18 @@
+import { pathToFileURL } from 'url'
+import { resolve } from 'path'
+import { ZodError } from 'zod'
+import { schema } from './schema'
+import type { Config } from './types'
+
+export async function loadConfig(configPath: string): Promise<Config> {
+  const module = await import(pathToFileURL(resolve(configPath)).href)
+  const rawConfig = module.default ?? module
+  try {
+    return schema.parse(rawConfig)
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new Error(`Invalid config: ${JSON.stringify(error.format(), null, 2)}`)
+    }
+    throw error
+  }
+}

--- a/packages/ts/src/config/schema.ts
+++ b/packages/ts/src/config/schema.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+
+export const schema = z.object({
+  swagger: z.string(),
+  output: z.string(),
+  mock: z.boolean().optional().default(false),
+  customMutators: z.boolean().optional().default(false),
+})

--- a/packages/ts/src/config/types.ts
+++ b/packages/ts/src/config/types.ts
@@ -1,0 +1,4 @@
+import { z } from 'zod'
+import { schema } from './schema'
+
+export type Config = z.infer<typeof schema>

--- a/packages/ts/src/index.ts
+++ b/packages/ts/src/index.ts
@@ -1,1 +1,5 @@
-export {};
+import type { Config } from './config/types'
+export { loadConfig } from './config/loadConfig'
+export type { Config } from './config/types'
+
+export const defineMocktailConfig = <T extends Config>(config: T): T => config

--- a/packages/ts/tsconfig.json
+++ b/packages/ts/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "ESNext",
     "strict": true,
     "outDir": "dist",
-    "declaration": true
+    "declaration": true,
+    "moduleResolution": "Node"
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add schema.ts, loadConfig.ts and types.ts for parsing config files
- expose `defineMocktailConfig` in package entry point
- document configuration usage
- update build settings and dependencies

## Testing
- `npx prettier -w packages/ts/src/config/schema.ts packages/ts/src/config/types.ts packages/ts/src/config/loadConfig.ts packages/ts/src/index.ts packages/ts/README.md README.md`
- `npx eslint packages/ts/src --fix`
- `pnpm --filter @mocktailgpt/ts run build`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ea0ac82108328af5a8336dea3a0b8