### PR TITLE
feat(orval): generate orval config dynamically from mocktail config

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,6 @@ Standard tooling is configured at the repository root:
 - Prettier for code formatting
 - ESLint with TypeScript support
 - Shared TypeScript settings in `tsconfig.base.json`
+- Husky pre-commit hook running lint-staged in packages
 
 See the package README for configuration details.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This repository houses multiple packages for the MocktailGPT project.
 ## Packages
 
 - [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
-  with MSW mocks and a `mocktail` command line interface
+  with MSW mocks and a `mocktail` command line interface. The package can also
+  generate an `orval.config.js` for programmatic use of [Orval](https://orval.dev).
 
 ## Development
 

--- a/packages/ts/.husky/_/husky.sh
+++ b/packages/ts/.husky/_/husky.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+if [ -z "$husky_skip_init" ]; then
+  debug() {
+    [ "$HUSKY_DEBUG" = "1" ] && echo "husky (debug) -" "$@"
+  }
+  readonly hook_name="$(basename "$0")"
+  debug "starting $hook_name..."
+  if [ -f ~/.huskyrc ]; then
+    debug "~/.huskyrc found, running..."
+    . ~/.huskyrc
+  fi
+  export readonly husky_skip_init=1
+  sh -e "$0" "$@"
+  exitCode=$?
+  debug "$hook_name finished with $exitCode exit code"
+  exit $exitCode
+fi

--- a/packages/ts/.husky/pre-commit
+++ b/packages/ts/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -43,3 +43,20 @@ Run the generator directly from your terminal:
 ```bash
 npx mocktail generate --config ./mocktail.config.ts
 ```
+
+## Development
+
+Available scripts:
+
+```bash
+pnpm build         # compile TypeScript
+pnpm clean         # remove build output and generated config
+pnpm dev           # clean then build
+pnpm format        # format source files
+pnpm format:check  # check formatting
+pnpm lint          # run ESLint
+pnpm lint:fix      # fix lint issues
+```
+
+Installing dependencies will run `pnpm prepare` to set up Husky.
+The pre-commit hook formats and lints staged files via `lint-staged`.

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -24,6 +24,18 @@ import { loadConfig } from '@mocktailgpt/ts'
 const config = await loadConfig('./mocktail.config.ts')
 ```
 
+### Generate an Orval configuration
+
+With the validated config you can create an `orval.config.js` for programmatic usage:
+
+```ts
+import { generateOrvalConfig } from '@mocktailgpt/ts'
+
+const orvalConfigPath = generateOrvalConfig(config)
+// then use it with orval
+// await generate(orvalConfigPath)
+```
+
 ## CLI
 
 Run the generator directly from your terminal:

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -14,16 +14,37 @@
     "mocktail": "./dist/cli.js"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist orval.config.js",
+    "dev": "pnpm clean && pnpm build",
+    "format": "prettier --write 'src/**/*.{ts,js,json,md}'",
+    "format:check": "prettier --check 'src/**/*.{ts,js,json,md}'",
+    "lint": "eslint 'src/**/*.{ts,js}'",
+    "lint:fix": "eslint 'src/**/*.{ts,js}' --fix",
+    "prepare": "husky install"
   },
   "files": [
     "dist"
   ],
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.34.0",
+    "@typescript-eslint/parser": "^8.34.0",
+    "eslint": "^9.29.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.1.2",
+    "prettier": "^3.5.3",
     "typescript": "^5.8.3"
   },
   "dependencies": {
-    "zod": "^3.25.64",
-    "ora": "^8.2.0"
+    "ora": "^8.2.0",
+    "zod": "^3.25.64"
+  },
+  "lint-staged": {
+    "src/**/*.{ts,js}": [
+      "eslint --fix"
+    ],
+    "src/**/*.{ts,js,json,md}": [
+      "prettier --write"
+    ]
   }
 }

--- a/packages/ts/src/generator/generateOrvalConfig.ts
+++ b/packages/ts/src/generator/generateOrvalConfig.ts
@@ -1,0 +1,35 @@
+import { writeFileSync } from 'fs'
+import { join, resolve, dirname, parse } from 'path'
+import { fileURLToPath } from 'url'
+import { createRequire } from 'module'
+import type { Config } from '../config/types'
+
+const require = createRequire(import.meta.url)
+
+export function getOrvalConfigObject(config: Config) {
+  const apiName = parse(config.swagger).name
+  return {
+    [apiName]: {
+      input: config.swagger,
+      output: {
+        target: join(config.output, 'client.ts'),
+        schemas: join(config.output, 'model'),
+        client: 'fetch',
+        mock: config.mock,
+      },
+      mutator: {
+        path: require.resolve('../logic/mutators/globalMutatorFactory.ts'),
+        name: 'globalMutator',
+      },
+    },
+  }
+}
+
+export function generateOrvalConfig(config: Config): string {
+  const orvalConfig = getOrvalConfigObject(config)
+  const __dirname = dirname(fileURLToPath(import.meta.url))
+  const filePath = resolve(__dirname, '../../orval.config.js')
+  const content = `module.exports = ${JSON.stringify(orvalConfig, null, 2)}\n`
+  writeFileSync(filePath, content)
+  return filePath
+}

--- a/packages/ts/src/index.ts
+++ b/packages/ts/src/index.ts
@@ -1,5 +1,7 @@
 import type { Config } from './config/types'
 export { loadConfig } from './config/loadConfig'
 export type { Config } from './config/types'
+export { generateOrvalConfig } from './generator/generateOrvalConfig'
+export { getOrvalConfigObject } from './generator/generateOrvalConfig'
 
 export const defineMocktailConfig = <T extends Config>(config: T): T => config


### PR DESCRIPTION
## Summary
- generate an Orval configuration file from a `mocktail` config
- expose helpers in the entrypoint
- document the new utility in package README and root README

## Testing
- `npx prettier -w .`
- `npx eslint packages/ts/src --ext .ts`
- `pnpm --filter @mocktailgpt/ts run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ea39652a48328aa5ec47115b5ad70