### PR TITLE
feat: execute orval programmatically from CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ This repository houses multiple packages for the MocktailGPT project.
 ## Packages
 
 [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
-  with MSW mocks and a `mocktail` command line interface. The package can also
-  generate an `orval.config.js` and now runs [Orval](https://orval.dev) programmatically.
+  with MSW mocks and a `mocktail` command line interface. The package can
+  generate an `orval.config.js` and run [Orval](https://orval.dev) programmatically.
+  Use `-c` or `--config` to point to a custom Orval configuration.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This repository houses multiple packages for the MocktailGPT project.
 
 ## Packages
 
-- [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
+[@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
   with MSW mocks and a `mocktail` command line interface. The package can also
-  generate an `orval.config.js` for programmatic use of [Orval](https://orval.dev).
+  generate an `orval.config.js` and now runs [Orval](https://orval.dev) programmatically.
 
 ## Development
 

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -38,11 +38,12 @@ const orvalConfigPath = generateOrvalConfig(config)
 
 ## CLI
 
-Run the generator directly from your terminal. The CLI will create an
-`orval.config.js` in the current directory and run Orval programmatically:
+Run the generator directly from your terminal. The CLI creates an
+`orval.config.js` in the current directory and runs Orval programmatically.
+You can pass `-c` or `--config` to use a custom Orval configuration path:
 
 ```bash
-npx mocktail generate --config ./mocktail.config.ts
+npx mocktail generate --config ./mocktail.config.ts -c ./orval.config.js
 ```
 
 ## Development

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -38,7 +38,8 @@ const orvalConfigPath = generateOrvalConfig(config)
 
 ## CLI
 
-Run the generator directly from your terminal:
+Run the generator directly from your terminal. The CLI will create an
+`orval.config.js` in the current directory and run Orval programmatically:
 
 ```bash
 npx mocktail generate --config ./mocktail.config.ts

--- a/packages/ts/package.json
+++ b/packages/ts/package.json
@@ -32,6 +32,7 @@
     "eslint": "^9.29.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.2",
+    "orval": "^7.10.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3"
   },

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import ora from 'ora'
+import { resolve } from 'path'
 import { loadConfig } from './config/loadConfig'
+import { generateOrvalConfig } from './generator/generateOrvalConfig'
 
 async function main() {
   const args = process.argv.slice(2)
@@ -19,7 +21,15 @@ async function main() {
   try {
     const config = await loadConfig(configPath)
     spinner.succeed('Config loaded')
-    console.log(config)
+
+    generateOrvalConfig(config)
+    const orval = await import('orval')
+    await orval.runCLI(resolve(process.cwd(), 'orval.config.js')).catch((err: unknown) => {
+      console.error('❌ Orval generation failed:', err)
+      process.exit(1)
+    })
+
+    console.log('🎉 Orval generation complete')
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     if (message.startsWith('Invalid config')) {

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import ora from 'ora'
 import { resolve } from 'path'
+import { runCLI } from 'orval'
 import { loadConfig } from './config/loadConfig'
 import { generateOrvalConfig } from './generator/generateOrvalConfig'
 
@@ -23,13 +24,20 @@ async function main() {
     spinner.succeed('Config loaded')
 
     generateOrvalConfig(config)
-    const orval = await import('orval')
-    await orval.runCLI(resolve(process.cwd(), 'orval.config.js')).catch((err: unknown) => {
+
+    const configArgIndex = args.findIndex((arg) => arg === '--config' || arg === '-c')
+    const orvalConfigPath =
+      configArgIndex !== -1
+        ? resolve(process.cwd(), args[configArgIndex + 1])
+        : resolve(process.cwd(), 'orval.config.js')
+
+    try {
+      await runCLI(['--config', orvalConfigPath])
+      console.log('✅ Orval generation complete')
+    } catch (err) {
       console.error('❌ Orval generation failed:', err)
       process.exit(1)
-    })
-
-    console.log('🎉 Orval generation complete')
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
     if (message.startsWith('Invalid config')) {

--- a/packages/ts/src/types/orval.d.ts
+++ b/packages/ts/src/types/orval.d.ts
@@ -1,0 +1,3 @@
+declare module 'orval' {
+  export function runCLI(args: string[]): Promise<void>
+}

--- a/packages/ts/tsconfig.json
+++ b/packages/ts/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "outDir": "dist",
     "declaration": true,
-    "moduleResolution": "Node"
+    "moduleResolution": "Node",
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- run Orval using `runCLI` after generating the config
- document that the CLI runs Orval programmatically
- note Orval execution in root README
- fix path import for ESM

## Testing
- `pnpm --filter @mocktailgpt/ts format`
- `pnpm --filter @mocktailgpt/ts lint`
- `pnpm --filter @mocktailgpt/ts build` *(fails: Cannot find module 'orval' type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_684ea64afc048328bb5c5d7fba67a7c1