### PR TITLE
feat: post Orval generation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This repository houses multiple packages for the MocktailGPT project.
 
 [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
   with MSW mocks and a `mocktail` command line interface. The package can
-  generate an `orval.config.js` and run [Orval](https://orval.dev) programmatically.
+  generate an `orval.config.js`, run [Orval](https://orval.dev), and create
+  helper files (`index.ts`, `msw.ts`, `mockServiceWorker.js`).
   Use `-c` or `--config` to point to a custom Orval configuration.
 
 ## Development

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -40,6 +40,12 @@ const orvalConfigPath = generateOrvalConfig(config)
 
 Run the generator directly from your terminal. The CLI creates an
 `orval.config.js` in the current directory and runs Orval programmatically.
+After Orval completes it also generates helper files in the output directory:
+
+- `index.ts` that re-exports all generated modules
+- `msw.ts` exposing a `handlers` array from the mocks
+- `mockServiceWorker.js` starting an MSW worker
+
 You can pass `-c` or `--config` to use a custom Orval configuration path:
 
 ```bash

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from 'path'
 import { runCLI } from 'orval'
 import { loadConfig } from './config/loadConfig'
 import { generateOrvalConfig } from './generator/generateOrvalConfig'
+import { generatePostFiles } from './generator/generatePostFiles'
 
 async function main() {
   const args = process.argv.slice(2)
@@ -34,6 +35,7 @@ async function main() {
     try {
       await runCLI(['--config', orvalConfigPath])
       console.log('✅ Orval generation complete')
+      generatePostFiles(resolve(process.cwd(), config.output))
     } catch (err) {
       console.error('❌ Orval generation failed:', err)
       process.exit(1)

--- a/packages/ts/src/generator/generatePostFiles.ts
+++ b/packages/ts/src/generator/generatePostFiles.ts
@@ -1,0 +1,39 @@
+import { readdirSync, writeFileSync } from 'fs'
+import { join, relative } from 'path'
+
+function collectTsFiles(dir: string, base: string = dir): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return collectTsFiles(fullPath, base)
+    }
+    if (
+      entry.isFile() &&
+      entry.name.endsWith('.ts') &&
+      entry.name !== 'index.ts' &&
+      entry.name !== 'msw.ts'
+    ) {
+      return [relative(base, fullPath).replace(/\\/g, '/')]
+    }
+    return []
+  })
+}
+
+export function generatePostFiles(baseDir: string) {
+  const files = collectTsFiles(baseDir)
+  const exportLines = files
+    .map((file) => `export * from './${file.replace(/\.ts$/, '')}';`)
+    .join('\n')
+  writeFileSync(join(baseDir, 'index.ts'), exportLines + '\n')
+
+  const mswContent =
+    "import { handlers as defaultHandlers } from './default/default.msw';\n" +
+    'export const handlers = [...defaultHandlers];\n'
+  writeFileSync(join(baseDir, 'msw.ts'), mswContent)
+
+  const workerContent =
+    "import { setupWorker } from 'msw';\n" +
+    "import { handlers } from './msw';\n" +
+    'export const worker = setupWorker(...handlers);\n'
+  writeFileSync(join(baseDir, 'mockServiceWorker.js'), workerContent)
+}


### PR DESCRIPTION
## Summary
- run `mocktail generate` to create index.ts, msw.ts and mockServiceWorker.js after Orval
- document the new behaviour in package and repo READMEs

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_684ea9f4e05c8328b1bc8425ddab0902