### PR TITLE
Add init command to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ This repository houses multiple packages for the MocktailGPT project.
   helper files (`index.ts`, `msw.ts`, `mockServiceWorker.js`).
   Use `-c` or `--config` to point to a custom Orval configuration.
 
+The CLI also offers an `init` command to scaffold a `mocktail.config.ts` from a
+Swagger file:
+
+```bash
+mocktail init --swagger ./path/to/swagger.yaml
+```
+
 ## Development
 
 Standard tooling is configured at the repository root:

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -38,7 +38,14 @@ const orvalConfigPath = generateOrvalConfig(config)
 
 ## CLI
 
-Run the generator directly from your terminal. The CLI creates an
+Run the generator directly from your terminal. The CLI offers an `init` command
+to scaffold a `mocktail.config.ts` from a Swagger file:
+
+```bash
+mocktail init --swagger ./swagger.yaml
+```
+
+It also creates an
 `orval.config.js` in the current directory and runs Orval programmatically.
 After Orval completes it also generates helper files in the output directory:
 

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -1,14 +1,36 @@
 #!/usr/bin/env node
 import ora from 'ora'
-import { resolve } from 'path'
+import { resolve, relative } from 'path'
+import { existsSync, writeFileSync } from 'fs'
 import { runCLI } from 'orval'
 import { loadConfig } from './config/loadConfig'
 import { generateOrvalConfig } from './generator/generateOrvalConfig'
 import { generatePostFiles } from './generator/generatePostFiles'
+import { formatWithPrettier } from './utils/formatWithPrettier'
 
 async function main() {
   const args = process.argv.slice(2)
   const command = args[0]
+
+  if (command === 'init') {
+    const swaggerIndex = args.indexOf('--swagger')
+    if (swaggerIndex === -1) {
+      console.error('Missing --swagger <path> argument')
+      process.exit(1)
+    }
+    const swaggerPath = resolve(process.cwd(), args[swaggerIndex + 1])
+    const configFile = resolve(process.cwd(), 'mocktail.config.ts')
+    if (existsSync(configFile)) {
+      console.error('mocktail.config.ts already exists')
+      process.exit(1)
+    }
+    const relSwagger = relative(process.cwd(), swaggerPath).replace(/\\/g, '/')
+    const content = `import type { MocktailConfig } from '@mocktailgpt/ts';\n\nconst config: MocktailConfig = {\n  input: './${relSwagger}',\n  output: './api/generated',\n  clientName: 'default',\n  generateMock: true,\n};\n\nexport default config;\n`
+    writeFileSync(configFile, content)
+    await formatWithPrettier(configFile)
+    console.log('✅ mocktail.config.ts created')
+    return
+  }
 
   if (command !== 'generate') {
     console.error('Unknown command:', command)

--- a/packages/ts/src/utils/formatWithPrettier.ts
+++ b/packages/ts/src/utils/formatWithPrettier.ts
@@ -1,0 +1,14 @@
+import { readFileSync, writeFileSync } from 'fs'
+import { resolve } from 'path'
+
+export async function formatWithPrettier(filePath: string) {
+  try {
+    const prettier = await import('prettier')
+    const resolved = resolve(filePath)
+    const content = readFileSync(resolved, 'utf8')
+    const formatted = await prettier.format(content, { filepath: resolved })
+    writeFileSync(resolved, formatted)
+  } catch {
+    // Prettier not installed
+  }
+}


### PR DESCRIPTION
## Summary
- support `mocktail init` to scaffold `mocktail.config.ts`
- format generated config when prettier is available
- document the new command in READMEs

## Testing
- `pnpm --filter @mocktailgpt/ts clean`
- `pnpm --filter @mocktailgpt/ts build`
- `pnpm --filter @mocktailgpt/ts format`
- `pnpm --filter @mocktailgpt/ts lint`


------
https://chatgpt.com/codex/tasks/task_e_684eab80b98c83289427bc407bb342c1