### PR TITLE
feat: implement SDK generation from resolved config with orval

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ This repository houses multiple packages for the MocktailGPT project.
 
 [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
 with MSW mocks and a `mocktail` command line interface. The package can
-generate an `orval.config.js`, run [Orval](https://orval.dev), and create
-helper files (`index.ts`, `msw.ts`, `mockServiceWorker.js`).
+generate an `orval.config.js`, run [Orval](https://orval.dev) (either via the
+CLI or programmatically with `generateSDKFromConfig`), and create helper files
+(`index.ts`, `msw.ts`, `mockServiceWorker.js`).
 Use `-c` or `--config` to point to a custom Orval configuration.
 
 The CLI also offers an `init` command to scaffold a `mocktail.config.ts` from a

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "prepare": "husky install",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write .",
@@ -24,7 +24,8 @@
     "husky": "^9.0.11",
     "lint-staged": "^15.2.2",
     "prettier": "^3.0.3",
-    "rimraf": "^5.0.5"
+    "rimraf": "^5.0.5",
+    "vitest": "^1.4.0"
   },
   "lint-staged": {
     "**/*.{ts,js,json}": "prettier --write",

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -36,6 +36,16 @@ const orvalConfigPath = generateOrvalConfig(config);
 // await generate(orvalConfigPath)
 ```
 
+### Generate the SDK programmatically
+
+If you prefer to run Orval directly, use `generateSDKFromConfig`:
+
+```ts
+import { generateSDKFromConfig } from '@mocktailgpt/ts';
+
+await generateSDKFromConfig(config);
+```
+
 ## CLI
 
 Run the generator directly from your terminal. The CLI offers an `init` command

--- a/packages/ts/src/generator/generateSDKFromConfig.ts
+++ b/packages/ts/src/generator/generateSDKFromConfig.ts
@@ -1,0 +1,45 @@
+import { resolve, parse } from 'path';
+import { spawn } from 'child_process';
+import ora from 'ora';
+import { generateOrvalConfig } from './generateOrvalConfig';
+import { generatePostFiles } from './generatePostFiles';
+import type { Config } from '../config/types';
+
+export async function generateSDKFromConfig(config: Config) {
+  const name = parse(config.swagger).name;
+  const spinner = ora(`Generating SDK for ${name}...`).start();
+
+  try {
+    const orvalConfigPath = generateOrvalConfig(config);
+
+    const runOrval = await getOrvalRunner();
+    await runOrval(orvalConfigPath);
+
+    generatePostFiles(resolve(process.cwd(), config.output));
+    spinner.succeed(`✅ SDK generated for ${name}`);
+  } catch (error) {
+    spinner.fail('SDK generation failed');
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+async function getOrvalRunner() {
+  try {
+    const mod = await import('orval');
+    return async (configPath: string) => {
+      await mod.runCLI(['--config', configPath]);
+    };
+  } catch {
+    return async (configPath: string) => {
+      await new Promise<void>((resolvePromise, reject) => {
+        const child = spawn('npx', ['orval', '--config', configPath], {
+          stdio: 'inherit',
+        });
+        child.on('exit', (code) => {
+          code === 0 ? resolvePromise() : reject(new Error(`Orval CLI exited with code ${code}`));
+        });
+        child.on('error', reject);
+      });
+    };
+  }
+}

--- a/packages/ts/src/test/generateSDKFromConfig.test.ts
+++ b/packages/ts/src/test/generateSDKFromConfig.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Config } from '../config/types';
+import { generateSDKFromConfig } from '../generator/generateSDKFromConfig';
+
+vi.mock('../generator/generateOrvalConfig', () => ({
+  generateOrvalConfig: vi.fn(() => 'mock-orval.config.js'),
+}));
+
+vi.mock('../generator/generatePostFiles', () => ({
+  generatePostFiles: vi.fn(),
+}));
+
+const runCLIMock = vi.fn().mockResolvedValue(undefined);
+vi.mock('orval', () => ({ runCLI: runCLIMock }));
+
+vi.mock('ora', () => {
+  const succeed = vi.fn();
+  const fail = vi.fn();
+  const start = vi.fn(() => ({ succeed, fail }));
+  (globalThis as any).oraStart = start;
+  (globalThis as any).oraSucceed = succeed;
+  return { default: () => ({ start, succeed, fail }) };
+});
+
+describe('generateSDKFromConfig', () => {
+  it('runs orval and updates spinner', async () => {
+    const config: Config = {
+      swagger: './swagger.yaml',
+      output: './out',
+      mock: false,
+      customMutators: false,
+    };
+
+    await generateSDKFromConfig(config);
+
+    const start = (globalThis as any).oraStart;
+    const succeed = (globalThis as any).oraSucceed;
+
+    expect(start).toHaveBeenCalled();
+    expect(runCLIMock).toHaveBeenCalledWith(['--config', 'mock-orval.config.js']);
+    expect(succeed).toHaveBeenCalledWith('✅ SDK generated for swagger');
+  });
+});


### PR DESCRIPTION
## Summary
- add `generateSDKFromConfig` to run orval programmatically or via CLI
- document SDK generation in READMEs
- add minimal Vitest unit test
- configure vitest in project scripts

## Testing
- `pnpm test`
- `pnpm lint` *(fails: A config object is using the "root" key, which is not supported in flat config system.)*
- `pnpm format`

------
https://chatgpt.com/codex/tasks/task_e_684eb0794d608328826d0673e1546a23