### PR TITLE
feat(run-orval): generate orval config and execute orval CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository houses multiple packages for the MocktailGPT project.
 
 [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
 with MSW mocks and a `mocktail` command line interface. The package can
-generate a `.mocktail/orval.temp.config.ts`, run [Orval](https://orval.dev) (either via the
+generate a `mocktail.orval.config.ts`, run [Orval](https://orval.dev) (either via the
 CLI or programmatically with `generateSDKFromConfig`), and create helper files
 (`index.ts`, `msw.ts`, `mockServiceWorker.js`).
 

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -29,13 +29,13 @@ configuration fails validation.
 
 ### Generate an Orval configuration
 
-With the validated config you can create a `.mocktail/orval.temp.config.ts` for programmatic usage:
+With the validated config you can create a `mocktail.orval.config.ts` for programmatic usage:
 
 ```ts
 import { generateOrvalConfig } from '@mocktailgpt/ts';
 
-const orvalConfigPath = generateOrvalConfig(config);
-// orvalConfigPath points to .mocktail/orval.temp.config.ts
+const orvalConfigPath = await generateOrvalConfig(config);
+// orvalConfigPath points to mocktail.orval.config.ts
 // await generate(orvalConfigPath)
 ```
 
@@ -58,8 +58,7 @@ to scaffold a `mocktail.config.ts` from a Swagger file:
 mocktail init --swagger ./swagger.yaml
 ```
 
-It also creates an
-`.mocktail/orval.temp.config.ts` in the current directory and runs Orval programmatically.
+It also creates a `mocktail.orval.config.ts` in the current directory and runs Orval programmatically.
 After Orval completes it also generates helper files in the output directory:
 
 - `index.ts` that re-exports all generated modules

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -46,23 +46,18 @@ async function main() {
     const config = await loadConfig(configPath);
     spinner.succeed('Config loaded');
 
-    const orvalConfigPath = generateOrvalConfig(config);
+    spinner.start('Writing Orval config...');
+    const orvalConfigPath = await generateOrvalConfig(config);
+    spinner.succeed('✔ Orval config written');
 
-    try {
-      await runCLI(['--config', orvalConfigPath]);
-      console.log('✅ Orval generation complete');
-      await generatePostFiles(resolve(process.cwd(), config.output));
-    } catch (err) {
-      console.error('❌ Orval generation failed:', err);
-      process.exit(1);
-    }
+    spinner.start('Generating Orval client...');
+    await runCLI(orvalConfigPath);
+    spinner.succeed('✔ Orval client generated');
+
+    await generatePostFiles(resolve(process.cwd(), config.output));
   } catch (error) {
+    spinner.fail('Generation failed');
     const message = error instanceof Error ? error.message : String(error);
-    if (message.startsWith('Invalid config')) {
-      spinner.fail('❌ Invalid config');
-    } else {
-      spinner.fail('Error loading config');
-    }
     console.error(message);
     process.exit(1);
   }

--- a/packages/ts/src/generator/generateSDKFromConfig.ts
+++ b/packages/ts/src/generator/generateSDKFromConfig.ts
@@ -10,7 +10,7 @@ export async function generateSDKFromConfig(config: Config) {
   const spinner = ora(`Generating SDK for ${name}...`).start();
 
   try {
-    const orvalConfigPath = generateOrvalConfig(config);
+    const orvalConfigPath = await generateOrvalConfig(config);
 
     const runOrval = await getOrvalRunner();
     await runOrval(orvalConfigPath);
@@ -27,7 +27,7 @@ async function getOrvalRunner() {
   try {
     const mod = await import('orval');
     return async (configPath: string) => {
-      await mod.runCLI(['--config', configPath]);
+      await mod.runCLI(configPath);
     };
   } catch {
     return async (configPath: string) => {

--- a/packages/ts/src/index.ts
+++ b/packages/ts/src/index.ts
@@ -1,7 +1,11 @@
 import type { Config } from './config/types';
 export { loadConfig } from './config/loadConfig';
 export type { Config } from './config/types';
-export { generateOrvalConfig } from './generator/generateOrvalConfig';
-export { getOrvalConfigObject } from './generator/generateOrvalConfig';
+export {
+  generateOrvalConfig,
+  getOrvalConfigObject,
+  writeOrvalConfig,
+} from './generator/generateOrvalConfig';
+export type { OrvalConfigObject } from './generator/generateOrvalConfig';
 
 export const defineMocktailConfig = <T extends Config>(config: T): T => config;

--- a/packages/ts/src/test/generateSDKFromConfig.test.ts
+++ b/packages/ts/src/test/generateSDKFromConfig.test.ts
@@ -9,7 +9,7 @@ declare global {
 }
 
 vi.mock('../generator/generateOrvalConfig', () => ({
-  generateOrvalConfig: vi.fn(() => 'mock-orval.temp.config.ts'),
+  generateOrvalConfig: vi.fn(async () => 'mock-orval.temp.config.ts'),
 }));
 
 vi.mock('../generator/generatePostFiles', () => ({
@@ -45,7 +45,7 @@ describe('generateSDKFromConfig', () => {
     const succeed = globalThis.oraSucceed!;
 
     expect(start).toHaveBeenCalled();
-    expect(runCLIMock).toHaveBeenCalledWith(['--config', 'mock-orval.temp.config.ts']);
+    expect(runCLIMock).toHaveBeenCalledWith('mock-orval.temp.config.ts');
     expect(generatePostFiles).toHaveBeenCalledWith(resolve(process.cwd(), config.output));
     expect(succeed).toHaveBeenCalledWith('✅ SDK generated for swagger');
   });

--- a/packages/ts/src/types/orval.d.ts
+++ b/packages/ts/src/types/orval.d.ts
@@ -1,3 +1,3 @@
 declare module 'orval' {
-  export function runCLI(args: string[]): Promise<void>;
+  export function runCLI(configPath: string): Promise<void>;
 }


### PR DESCRIPTION
## Summary
- generate `mocktail.orval.config.ts` from user config
- run Orval CLI with the generated config
- log steps with `ora`
- adjust SDK generator and type definitions
- update documentation

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ebb1e89ec8328a4766c53189e0823