### PR TITLE
feat(mock): generate msw.ts and copy mockServiceWorker.js when mock:true

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ This repository houses multiple packages for the MocktailGPT project.
 ## Packages
 
 [@mocktailgpt/ts](packages/ts): CLI scaffold for generating TypeScript clients
-with MSW mocks and a `mocktail` command line interface. The package can
-generate a `mocktail.orval.config.ts`, run [Orval](https://orval.dev) (either via the
-CLI or programmatically with `generateSDKFromConfig`), and create helper files
-(`index.ts`, `msw.ts`, `mockServiceWorker.js` when `postFiles.enabled` is set).
+with MSW mocks and a `mocktail` command line interface. The package can generate
+a `mocktail.orval.config.ts`, run [Orval](https://orval.dev) either via the CLI
+or programmatically with `generateSDKFromConfig`, and produce MSW mocks. When
+`mock` is enabled, an `msw.ts` file aggregates all handlers and
+`mockServiceWorker.js` is copied to `public/`.
 
 The CLI also offers an `init` command to scaffold a `mocktail.config.ts` from an
 OpenAPI file:

--- a/packages/ts/README.md
+++ b/packages/ts/README.md
@@ -29,7 +29,7 @@ Available options (all optional):
 - `output` _(default: `'src/api'`)_ – destination folder for the generated SDK
 - `projectName` _(default: `'default'`)_ – name used for the Orval entry
 - `mock` _(default: `true`)_ – enable MSW mock generation
-- `postFiles` – generate helper files (`index.ts`, `msw.ts`, `mockServiceWorker.js`)
+- `postFiles` – generate helper files (`index.ts`)
 
 Load it in your scripts with:
 
@@ -77,8 +77,9 @@ It also creates a `mocktail.orval.config.ts` in the current directory and runs O
 If `postFiles.enabled` is true, helper files are generated after Orval:
 
 - `index.ts` re-exporting the client, models and mocks
-- `msw.ts` exposing a ready-to-use MSW `worker`
-- `mockServiceWorker.js` copied from the `msw` package
+
+When `mock` is enabled, all `*.msw.ts` files are aggregated into `msw.ts` and
+`mockServiceWorker.js` is copied into the `public/` directory (if missing).
 
 Future versions may add extra helpers or type definitions.
 

--- a/packages/ts/src/cli.ts
+++ b/packages/ts/src/cli.ts
@@ -6,6 +6,7 @@ import { runCLI } from 'orval';
 import { loadConfig } from './config/loadConfig';
 import { generateOrvalConfig } from './generator/generateOrvalConfig';
 import { generatePostFiles } from './generator/generatePostFiles';
+import { generateMockFiles } from './generator/generateMockFiles';
 import { formatWithPrettier } from './utils/formatWithPrettier';
 
 async function main() {
@@ -58,6 +59,12 @@ async function main() {
       await generatePostFiles(
         resolve(process.cwd(), config.output),
         resolve(process.cwd(), config.output, config.postFiles.output ?? '.'),
+      );
+    }
+    if (config.mock) {
+      await generateMockFiles(
+        resolve(process.cwd(), config.output),
+        resolve(process.cwd(), 'public'),
       );
     }
   } catch (error) {

--- a/packages/ts/src/generator/generateMockFiles.ts
+++ b/packages/ts/src/generator/generateMockFiles.ts
@@ -1,0 +1,45 @@
+import { readdir, mkdir, copyFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, relative, dirname } from 'path';
+import { formatWithPrettier } from '../utils/formatWithPrettier';
+
+async function findMswFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findMswFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith('.msw.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+export async function generateMockFiles(outputDir: string, publicDir: string) {
+  const mswFiles = await findMswFiles(outputDir);
+  if (mswFiles.length === 0) {
+    return;
+  }
+
+  const imports: string[] = [];
+  const spreads: string[] = [];
+  mswFiles.forEach((file, idx) => {
+    const rel = relative(outputDir, file).replace(/\\/g, '/').replace(/\.ts$/, '');
+    const varName = `handlers${idx}`;
+    imports.push(`import { handlers as ${varName} } from './${rel}';`);
+    spreads.push(`...${varName}`);
+  });
+  const content = `${imports.join('\n')}\n\nexport const handlers = [${spreads.join(', ')}];\n`;
+  const mswPath = join(outputDir, 'msw.ts');
+  await writeFile(mswPath, content);
+  await formatWithPrettier(mswPath);
+
+  const workerSource = require.resolve('msw/lib/mockServiceWorker.js');
+  const workerDest = join(publicDir, 'mockServiceWorker.js');
+  if (!existsSync(workerDest)) {
+    await mkdir(dirname(workerDest), { recursive: true });
+    await copyFile(workerSource, workerDest);
+  }
+}

--- a/packages/ts/src/generator/generateSDKFromConfig.ts
+++ b/packages/ts/src/generator/generateSDKFromConfig.ts
@@ -3,6 +3,7 @@ import { spawn } from 'child_process';
 import ora from 'ora';
 import { generateOrvalConfig } from './generateOrvalConfig';
 import { generatePostFiles } from './generatePostFiles';
+import { generateMockFiles } from './generateMockFiles';
 import type { Config } from '../config/types';
 
 export async function generateSDKFromConfig(config: Config) {
@@ -19,6 +20,12 @@ export async function generateSDKFromConfig(config: Config) {
       await generatePostFiles(
         resolve(process.cwd(), config.output),
         resolve(process.cwd(), config.output, config.postFiles.output ?? '.'),
+      );
+    }
+    if (config.mock) {
+      await generateMockFiles(
+        resolve(process.cwd(), config.output),
+        resolve(process.cwd(), 'public'),
       );
     }
     spinner.succeed(`✅ SDK generated for ${name}`);

--- a/packages/ts/src/test/generateSDKFromConfig.test.ts
+++ b/packages/ts/src/test/generateSDKFromConfig.test.ts
@@ -16,6 +16,10 @@ vi.mock('../generator/generatePostFiles', () => ({
   generatePostFiles: vi.fn(),
 }));
 
+vi.mock('../generator/generateMockFiles', () => ({
+  generateMockFiles: vi.fn(),
+}));
+
 const runCLIMock = vi.fn().mockResolvedValue(undefined);
 vi.mock('orval', () => ({ runCLI: runCLIMock }));
 
@@ -52,5 +56,23 @@ describe('generateSDKFromConfig', () => {
       resolve(process.cwd(), config.output),
     );
     expect(succeed).toHaveBeenCalledWith('✅ SDK generated for swagger');
+  });
+
+  it('generates mocks when enabled', async () => {
+    const config: Config = {
+      input: './swagger.yaml',
+      output: './out',
+      projectName: 'swagger',
+      mock: true,
+    };
+
+    const { generateMockFiles } = await import('../generator/generateMockFiles');
+
+    await generateSDKFromConfig(config);
+
+    expect(generateMockFiles).toHaveBeenCalledWith(
+      resolve(process.cwd(), config.output),
+      resolve(process.cwd(), 'public'),
+    );
   });
 });


### PR DESCRIPTION
## Summary
- generate msw handlers and service worker when `mock` is enabled
- add `generateMockFiles` helper
- invoke helper from CLI and programmatic generator
- document MSW generation
- unit test mock generation

## Testing
- `pnpm format`
- `pnpm lint`
- `pnpm test` *(fails: Missing "./api" specifier in "tsx" package)*

------
https://chatgpt.com/codex/tasks/task_e_684ec59638148328a482d14f6f996ec6