### PR TITLE
Add vanScrapper example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ Standard tooling is configured at the repository root:
 - Husky pre-commit hook running lint-staged
 
 See the package README for configuration details.
+
+## Examples
+
+A minimal React application demonstrating the Mocktail CLI is located in [example/vanScrapper](example/vanScrapper).
+Run `pnpm install` and `pnpm dev` inside this directory to start the app with MSW mocks enabled.
+Use `pnpm generate` to regenerate the API client from the provided OpenAPI spec.

--- a/example/vanScrapper/mocktail.config.ts
+++ b/example/vanScrapper/mocktail.config.ts
@@ -1,0 +1,12 @@
+import type { MocktailConfig } from '@mocktailgpt/ts';
+
+const config: MocktailConfig = {
+  input: './openapi.yaml',
+  output: './src/api/generated',
+  projectName: 'vanScrapper',
+  clientName: 'client',
+  mock: true,
+  postFiles: { enabled: true, output: '..' },
+};
+
+export default config;

--- a/example/vanScrapper/openapi.yaml
+++ b/example/vanScrapper/openapi.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  title: Van Scrapper API
+  version: 1.0.0
+paths:
+  /vans:
+    get:
+      operationId: getAllVanInfo
+      summary: Get all van information
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Van'
+components:
+  schemas:
+    Van:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/example/vanScrapper/package.json
+++ b/example/vanScrapper/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "van-scrapper",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "generate": "mocktail generate"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@mocktailgpt/ts": "workspace:*",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/example/vanScrapper/public/index.html
+++ b/example/vanScrapper/public/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Van Scrapper</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/example/vanScrapper/src/App.tsx
+++ b/example/vanScrapper/src/App.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import { getAllVanInfo } from './api';
+
+function App() {
+  const [data, setData] = useState<unknown>(null);
+
+  const search = async () => {
+    const res = await getAllVanInfo();
+    setData(res.data);
+  };
+
+  return (
+    <div>
+      <button onClick={search}>Rechercher un van</button>
+      {data && <pre>{JSON.stringify(data, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default App;

--- a/example/vanScrapper/src/api/index.ts
+++ b/example/vanScrapper/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './generated/client';
+export * from './msw';

--- a/example/vanScrapper/src/api/msw.ts
+++ b/example/vanScrapper/src/api/msw.ts
@@ -1,0 +1,14 @@
+import { rest, setupWorker } from 'msw';
+
+export const handlers = [
+  rest.get('/vans', (_req, res, ctx) =>
+    res(
+      ctx.json([
+        { id: '1', name: 'Camper Deluxe' },
+        { id: '2', name: 'Road Explorer' },
+      ]),
+    ),
+  ),
+];
+
+export const worker = setupWorker(...handlers);

--- a/example/vanScrapper/src/main.tsx
+++ b/example/vanScrapper/src/main.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import { worker } from './api/msw';
+
+if (import.meta.env.MODE === 'development') {
+  worker.start();
+}
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/example/vanScrapper/tsconfig.json
+++ b/example/vanScrapper/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["DOM", "ES2022"],
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/example/vanScrapper/vite.config.ts
+++ b/example/vanScrapper/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- add `example/vanScrapper` showing how to use `@mocktailgpt/ts`
- include mocktail config pointing to `openapi.yaml`
- minimal React app using MSW mocks
- document the new example in the repository README

## Testing
- `pnpm clean`
- `pnpm format`
- `pnpm lint`
- `pnpm test` *(fails: Missing "./api" specifier in "tsx" package)*

------
https://chatgpt.com/codex/tasks/task_e_684ece5916b88328ba9e55f13d5faf75